### PR TITLE
[excalidraw] add Excaliman TUI

### DIFF
--- a/AGENTs.md
+++ b/AGENTs.md
@@ -15,6 +15,7 @@ Excalidraw is structured as a **monorepo**:
 - **Testing**: Automatically run tests before finalizing changes (`yarn test:update` and `yarn test:typecheck`).
 - **Documentation**: Clearly document changes in Pull Requests.
 - **Instructions Editing**: For instructional project pages (e.g., project setup guides for Excalidraw and Excalidraw-Room), agents should generate detailed step-by-step README templates covering prerequisites, repository cloning, dependencies installation, server startup, and secure public sharing (e.g., ngrok tunnels or TUI controls); then place the README.md or Instructions.md in the respective project's root folder.
+
 ## Development Commands
 
 ```bash

--- a/Instructions.md
+++ b/Instructions.md
@@ -1,0 +1,50 @@
+# Excalidraw Local Setup Guide
+
+This guide shows how to run a local instance of Excalidraw and share it securely using ngrok.
+
+## Prerequisites
+
+- **Node.js** 14+
+- **npm** or **yarn**
+- **ngrok** (for public access)
+
+## 1. Clone the Repository
+
+```bash
+git clone https://github.com/Queen-to-be-Constance-Budgiesnuggler/excalidraw.git
+cd excalidraw
+```
+
+## 2. Install Dependencies
+
+```bash
+npm install
+# or
+# yarn install
+```
+
+## 3. Start the Server
+
+```bash
+npm run start
+```
+
+Press Ctrl+C to stop the server when finished.
+
+Visit <http://localhost:3000> in your browser.
+
+## 4. Expose via ngrok
+
+In a new terminal, authenticate if needed:
+
+```bash
+ngrok authtoken YOUR_NGROK_TOKEN
+```
+
+Start a tunnel to port `3000`:
+
+```bash
+ngrok http 3000
+```
+
+Share the generated HTTPS forwarding URL to give others access.

--- a/TUI/Instructions.md
+++ b/TUI/Instructions.md
@@ -1,0 +1,48 @@
+# Excaliman Session Manager
+
+A GPU-friendly terminal interface for Kitty that controls an Excalidraw collaboration room and shares it through ngrok.
+
+## Prerequisites
+
+- **Python** 3.8+
+- **pip**
+- **textual** (or **tui-kit**)
+- **pyngrok**
+
+## 1. Clone the Repository
+
+```bash
+git clone https://github.com/Queen-to-be-Constance-Budgiesnuggler/excalidraw-room.git
+cd excalidraw-room
+```
+
+## 2. Install Dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+## 3. Configure Environment Variables
+
+Create a `.env` file:
+
+```
+EXCALIDRAW_URL=http://localhost:3000
+PORT=4000
+NGROK_AUTH_TOKEN=your_token_here
+```
+
+## 4. Launch the TUI Manager
+
+```bash
+python excalimanTUI.py
+```
+
+### TUI Controls
+
+- **s** — Start server and ngrok tunnel
+- **t** — Toggle tunnel
+- **x** — Stop
+- **q** — Quit
+
+The public URL appears under **🌐 Public URL:** in the interface.

--- a/TUI/README_TUI.md
+++ b/TUI/README_TUI.md
@@ -1,6 +1,6 @@
-# Excalidraw Tunnel Manager TUI
+# Excaliman Session Manager TUI
 
-This directory contains a Textual-based terminal UI for starting the Excalidraw servers, creating SSH tunnels and monitoring their status. The tool supports multiple environment presets, process restarts and log viewing.
+This directory contains a GPU-accelerated Textual UI designed for the Kitty terminal. It manages both Excalidraw and Excalidraw-Room servers, creates SSH tunnels and monitors their status. Multiple environments are supported along with automatic restarts and log viewing.
 
 The tool relies on the same commands you would normally use when developing Excalidraw locally. Common commands found across this repository include:
 
@@ -19,7 +19,7 @@ The default ports used during development are 3000 for the main app, 3002 for th
    pip install textual
    ```
 
-2. **Adjust configuration** Edit `excalidraw_tunnel_manager.py` and update the following constants at the top of the file:
+2. **Adjust configuration** Edit `excalimanTUI.py` and update the following constants at the top of the file:
    - `SERVER_PATH` / `ROOM_PATH` – paths to your local clones of `excalidraw` and `excalidraw-room` (e.g. `~/path/to/excalidraw`).
    - `SERVER_CMD` / `ROOM_CMD` – commands used to start the servers. Example values are `["yarn", "start"]` for the main app and `["yarn", "start:dev"]` for the Room server. Ensure these commands work locally before using the tunnel manager.
    - `SSH_HOST` – the host that will be used for SSH tunneling.
@@ -30,7 +30,7 @@ The default ports used during development are 3000 for the main app, 3002 for th
 From any terminal run:
 
 ```bash
-python excalidraw_tunnel_manager.py
+python excalimanTUI.py
 ```
 
 The UI lets you launch and stop the Excalidraw and Room servers, view their output in real time and automatically restart them if they crash. It can create and tear down tunnels and reboot everything with a single command. The manager supports multiple environments which define port mappings.

--- a/TUI/excalimanTUI.py
+++ b/TUI/excalimanTUI.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# excalidraw_tunnel_manager.py
-# A TUI application using Textual to manage Excalidraw and Excalidraw Room tunnels and servers.
+# excalimanTUI.py
+# A GPU‑accelerated Textual TUI for managing Excalidraw and Excalidraw Room servers via Kitty.
 
 import asyncio
 from textual.app import App, ComposeResult
@@ -41,9 +41,9 @@ ENVIRONMENTS = {
     },
 }
 
-class TunnelManager(App):
+class ExcalimanTUI(App):
     """
-    A Textual-based TUI for: 
+    A Textual-based GPU TUI for Kitty that allows you to:
       - Starting, rebooting, and exiting Excalidraw and Room servers
       - Establishing and tearing down SSH tunnels
       - Switching between dev and prod environments
@@ -214,4 +214,4 @@ class TunnelManager(App):
         self.shutting_down = False
 
 if __name__ == "__main__":
-    TunnelManager.run(title="Excalidraw Tunnel Manager")
+    ExcalimanTUI.run(title="Excaliman TUI")

--- a/TUI/tests/test_excalimanTUI.py
+++ b/TUI/tests/test_excalimanTUI.py
@@ -5,14 +5,14 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
-import TUI.excalidraw_tunnel_manager as etm
+import TUI.excalimanTUI as etm
 
 etm.SERVER_CMD = ["python", "-c", "print('server')"]
 etm.ROOM_CMD = ["python", "-c", "print('room')"]
 etm.SERVER_PATH = "."
 etm.ROOM_PATH = "."
 
-class TestManager(etm.TunnelManager):
+class TestManager(etm.ExcalimanTUI):
     async def start_tunnel(self, local_port: int, remote_port: int):
         proc = await asyncio.create_subprocess_exec("true")
         self.tunnel_proc.append(proc)


### PR DESCRIPTION
## Summary
- rename tunnel manager to `excalimanTUI.py`
- update TUI README and instructions for Kitty GPU terminal
- add setup guides for running Excalidraw locally
- adjust tests to import the renamed module

## Testing
- `yarn test:typecheck`
- `yarn test:update`
- `yarn fix`


------
https://chatgpt.com/codex/tasks/task_e_6877a9c465ec832f9faac9c4b8dd95e5